### PR TITLE
Fix mvn issuing 5k "we have a duplicate" warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
 			<groupId>com.hubspot.dropwizard</groupId>
 			<artifactId>dropwizard-guice</artifactId>
 			<version>0.6.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javassist</groupId>
+					<artifactId>javassist</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
dropwizard-guice depends on javassist 3.12.1, while
hibernate-entitymanager dpends on javassist 3.15.0. This lead to maven
issuing about 5k duplicate class warnings. This commit excludes the
older version of javassist, preventing those warnings.
